### PR TITLE
Poppler 0.84.0

### DIFF
--- a/buildScripts/versionEnvs
+++ b/buildScripts/versionEnvs
@@ -12,8 +12,8 @@
 #export POPPLER_VERSION=poppler-0.86.1
 #export POPPLER_VERSION=poppler-0.86.0
 #export POPPLER_VERSION=poppler-0.85.0
-#export POPPLER_VERSION=poppler-0.84.0
-export POPPLER_VERSION=poppler-0.83.0
+export POPPLER_VERSION=poppler-0.84.0
+#export POPPLER_VERSION=poppler-0.83.0
 #export POPPLER_VERSION=poppler-0.82.0
 #export POPPLER_VERSION=poppler-0.81.0
 

--- a/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -59,7 +59,7 @@ SplashBackgroundRenderer::SplashBackgroundRenderer(const string & imgFormat, HTM
 void SplashBackgroundRenderer::startPage(int pageNum, GfxState *state, XRef *xrefA)
 {
     SplashOutputDev::startPage(pageNum, state, xrefA);
-    clearModRegion();
+//    clearModRegion();
 }
 
 void SplashBackgroundRenderer::drawChar(GfxState *state, double x, double y,
@@ -127,8 +127,17 @@ void SplashBackgroundRenderer::embed_image(int pageno)
 {
     // xmin->xmax is top->bottom
     int xmin, xmax, ymin, ymax;
-    getModRegion(&xmin, &ymin, &xmax, &ymax);
-
+//    getModRegion(&xmin, &ymin, &xmax, &ymax);
+// poppler-0.84.0 hack to recover from the removal of ModRegion tracking 
+//
+	auto * bitmap = getBitmap();
+	xmin = 0;
+	xmax = bitmap->getWidth();
+	ymin = 0;
+	ymax = bitmap->getHeight();
+//
+// end of hack
+	
     // dump the background image only when it is not empty
     if((xmin <= xmax) && (ymin <= ymax))
     {

--- a/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -59,7 +59,6 @@ SplashBackgroundRenderer::SplashBackgroundRenderer(const string & imgFormat, HTM
 void SplashBackgroundRenderer::startPage(int pageNum, GfxState *state, XRef *xrefA)
 {
     SplashOutputDev::startPage(pageNum, state, xrefA);
-//    clearModRegion();
 }
 
 void SplashBackgroundRenderer::drawChar(GfxState *state, double x, double y,
@@ -127,8 +126,7 @@ void SplashBackgroundRenderer::embed_image(int pageno)
 {
     // xmin->xmax is top->bottom
     int xmin, xmax, ymin, ymax;
-//    getModRegion(&xmin, &ymin, &xmax, &ymax);
-// poppler-0.84.0 hack to recover from the removal of ModRegion tracking 
+// poppler-0.84.0 hack to recover from the removal of *ModRegion tracking 
 //
 	auto * bitmap = getBitmap();
 	xmin = 0;


### PR DESCRIPTION
Updated to poppler-0.84.0
Poppler 0.84.0 removed the ModRegion tracking.
We now use the bitmap's width and height (ie the whole bitmap).
This might increase the processing time as well as the output image sizes.