### PR TITLE
Clean up build

### DIFF
--- a/buildScripts/buildFontforge
+++ b/buildScripts/buildFontforge
@@ -18,12 +18,33 @@ cd build
 
 cmake        		                        \
   -DCMAKE_BUILD_TYPE=Release                \
-  -DBUILD_SHARED_LIBS:BOOL=OFF              \
   -DCMAKE_INSTALL_PREFIX=$PDF2HTMLEX_PREFIX \
+  -DBUILD_SHARED_LIBS:BOOL=OFF              \
   -DENABLE_GUI:BOOL=OFF                     \
   -DENABLE_X11:BOOL=OFF                     \
+  -DENABLE_NATIVE_SCRIPTING:BOOL=ON         \
   -DENABLE_PYTHON_SCRIPTING:BOOL=OFF        \
   -DENABLE_PYTHON_EXTENSION:AUTO=OFF        \
+  -DENABLE_LIBSPIRO:BOOL=ON                 \
+  -DENABLE_LIBUNINAMESLIST:BOOL=ON          \
+  -DENABLE_LIBGIF:AUTO=OFF                  \
+  -DENABLE_LIBJPEG:AUTO=ON                  \
+  -DENABLE_LIBPNG:AUTO=ON                   \
+  -DENABLE_LIBREADLINE:AUTO=OFF             \
+  -DENABLE_LIBTIFF:AUTO=OFF                 \
+  -DENABLE_WOFF2:AUTO=OFF                   \
+  -DENABLE_DOCS:AUTO=OFF                    \
+  -DENABLE_CODE_COVERAGE:BOOL=OFF           \
+  -DENABLE_DEBUG_RAW_POINTS:BOOL=OFF        \
+  -DENABLE_FONTFORGE_EXTRAS:BOOL=OFF        \
+  -DENABLE_MAINTAINER_TOOLS:BOOL=OFF        \
+  -DENABLE_TILE_PATH:BOOL=OFF               \
+  -DENABLE_WRITE_PFM:BOOL=OFF               \
+  -DENABLE_SANITIZER:ENUM="none"            \
+  -DENABLE_FREETYPE_DEBUGGER:PATH=""        \
+  -DSPHINX_USE_VENV:BOOL=OFF                \
+  -DREAL_TYPE:ENUM="double"                 \
+  -DTHEME:ENUM="tango"                      \
   ..
 
 # Apply any patches required for fontforge raw sources before we make
@@ -35,4 +56,34 @@ cmake        		                        \
 #done
 
 make $MAKE_PARALLEL
+
+##########################################################
+# FontForge CMakeLists.txt build options (2020/05/31):
+
+# BUILD_SHARED_LIBS:BOOL=OFF       "Build libfontforge as a shared library")
+# ENABLE_GUI:BOOL=OFF              "Build FontForge with GUI support")
+# ENABLE_X11:BOOL=OFF              "Build the GUI using the X backend INSTEAD of the GDK backend" "ENABLE_GUI")
+# ENABLE_NATIVE_SCRIPTING:BOOL=ON  "Enables FontForge's native scripting support")
+# ENABLE_PYTHON_SCRIPTING:BOOL=OFF "Enables FontForge's Python scripting support")
+# ENABLE_PYTHON_EXTENSION:AUTO=OFF "Builds the Python models for use with system python")
+# ENABLE_LIBSPIRO:BOOL=ON          "Enables libspiro support")
+# ENABLE_LIBUNINAMESLIST:BOOL=ON   "Enables libuninameslist support")
+# ENABLE_LIBGIF:AUTO=OFF           "Enables GIF support")
+# ENABLE_LIBJPEG:AUTO=ON           "Enables JPEG support")
+# ENABLE_LIBPNG:AUTO=ON            "Enables PNG support")
+# ENABLE_LIBREADLINE:AUTO=OFF      "Enables Readline support")
+# ENABLE_LIBTIFF:AUTO=OFF          "Enables TIFF support")
+# ENABLE_WOFF2:AUTO=OFF            "Enables WOFF2 support")
+# ENABLE_DOCS:AUTO=OFF             "Enables building and installing documentation. Sphinx is required to build it.")
+# ENABLE_CODE_COVERAGE:BOOL=OFF    "Build with code coverage support")
+# ENABLE_DEBUG_RAW_POINTS:BOOL=OFF "Add a raw mode to the points window of the debugger")
+# ENABLE_FONTFORGE_EXTRAS:BOOL=OFF "Builds programs from the contrib directory")
+# ENABLE_MAINTAINER_TOOLS:BOOL=OFF "Build programs normally only used by FontForge maintainers and developers")
+# ENABLE_TILE_PATH:BOOL=OFF        "Enable a 'tile path' command (a variant of 'expand stroke')")
+# ENABLE_WRITE_PFM:BOOL=OFF        "Add the ability to save a PFM file without creating the associated font file")
+# ENABLE_SANITIZER:ENUM="none"     "Enables a sanitizer. Requires support from the compiler."
+# ENABLE_FREETYPE_DEBUGGER:PATH="" "Use FreeTypes internal debugger within FontForge."
+# SPHINX_USE_VENV:BOOL=OFF         "If building documentation and Sphinx is not installed, try to install and use it from a python3 venv."
+# REAL_TYPE:ENUM="double"          "Sets the floating point type used." "double" "float")
+# THEME:ENUM="tango"               "Sets the GUI theme." "tango" "2012")
 

--- a/buildScripts/buildFontforge
+++ b/buildScripts/buildFontforge
@@ -25,8 +25,8 @@ cmake        		                        \
   -DENABLE_NATIVE_SCRIPTING:BOOL=ON         \
   -DENABLE_PYTHON_SCRIPTING:BOOL=OFF        \
   -DENABLE_PYTHON_EXTENSION:AUTO=OFF        \
-  -DENABLE_LIBSPIRO:BOOL=ON                 \
-  -DENABLE_LIBUNINAMESLIST:BOOL=ON          \
+  -DENABLE_LIBSPIRO:BOOL=OFF                \
+  -DENABLE_LIBUNINAMESLIST:BOOL=OFF         \
   -DENABLE_LIBGIF:AUTO=OFF                  \
   -DENABLE_LIBJPEG:AUTO=ON                  \
   -DENABLE_LIBPNG:AUTO=ON                   \

--- a/buildScripts/buildPoppler
+++ b/buildScripts/buildPoppler
@@ -4,7 +4,7 @@
 
 echo ""
 echo "-------------------------------------------------------------------"
-echo "BUILDING Poppler"
+echo "BUILDING Poppler (using CMake)"
 echo "-------------------------------------------------------------------"
 echo ""
 
@@ -13,8 +13,81 @@ mkdir build
 cd build
 cmake                                       \
   -DCMAKE_BUILD_TYPE=Release                \
-  -DBUILD_SHARED_LIBS:BOOL=OFF              \
   -DCMAKE_INSTALL_PREFIX=$PDF2HTMLEX_PREFIX \
-  -DENABLE_LIBOPENJPEG=none                 \
+  -DENABLE_UNSTABLE_API_ABI_HEADERS=OFF     \
+  -DBUILD_GTK_TESTS=OFF                     \
+  -DBUILD_QT5_TESTS=OFF                     \
+  -DBUILD_CPP_TESTS=OFF                     \
+  -DENABLE_SPLASH=ON                        \
+  -DENABLE_UTILS=OFF                        \
+  -DENABLE_CPP=ON                           \
+  -DENABLE_GLIB=ON                          \
+  -DENABLE_GOBJECT_INTROSPECTION=ON         \
+  -DENABLE_GTK_DOC=OFF                      \
+  -DENABLE_QT5=OFF                          \
+  -DENABLE_LIBOPENJPEG="none"               \
+  -DENABLE_CMS="lcms2"                      \
+  -DENABLE_DCTDECODER="libjpeg"             \
+  -DENABLE_LIBCURL=OFF                      \
+  -DENABLE_ZLIB=ON                          \
+  -DENABLE_ZLIB_UNCOMPRESS=OFF              \
+  -DUSE_FLOAT=OFF                           \
+  -DBUILD_SHARED_LIBS=OFF                   \
+  -DRUN_GPERF_IF_PRESENT=OFF                \
+  -DEXTRA_WARN=OFF                          \
   ..
+
 make $MAKE_PARALLEL
+
+
+###############################################################
+# Poppler CMakeLists.text build options (2020/05/31):
+
+# ENABLE_UNSTABLE_API_ABI_HEADERS=OFF "Install API/ABI unstable xpdf headers."
+# BUILD_GTK_TESTS=OFF                 "Whether to compile the GTK+ test programs."
+# BUILD_QT5_TESTS=OFF                 "Whether to compile the Qt5 test programs."
+# BUILD_CPP_TESTS=OFF                 "Whether to compile the CPP test programs."
+# ENABLE_SPLASH=ON                    "Build the Splash graphics backend."
+# ENABLE_UTILS=OFF                    "Compile poppler command line utils."
+# ENABLE_CPP=ON                       "Compile poppler cpp wrapper."
+# ENABLE_GLIB=ON                      "Compile poppler glib wrapper."
+# ENABLE_GOBJECT_INTROSPECTION=ON     "Whether to generate GObject introspection."
+# ENABLE_GTK_DOC=OFF                  "Whether to generate glib API documentation."
+# ENABLE_QT5=OFF                      "Compile poppler qt5 wrapper."
+#
+# ENABLE_LIBOPENJPEG="none"
+#
+# "Use libopenjpeg for JPX streams. Possible values: openjpeg2, 
+# unmaintained, none. 'unmaintained' gives you the internal unmaintained 
+# decoder. Use at your own risk. 'none' compiles no JPX decoder at all. 
+# Default: openjpeg2"
+#
+# ENABLE_CMS="lcms2"
+#
+# "Use color management system. Possible values: lcms2, none. 'none' 
+# disables color management system." 
+# 
+# ENABLE_DCTDECODER="libjpeg"
+#
+# "Use libjpeg for DCT streams. Possible values: libjpeg, unmaintained, 
+# none. will use libjpeg if available or fail if not. 'unmaintained' gives 
+# you the internal unmaintained decoder. Use at your own risk. 'none' 
+# compiles no DCT decoder at all. Default: libjpeg" 
+# 
+# ENABLE_LIBCURL=OFF                  "Build libcurl based HTTP support."
+# ENABLE_ZLIB=ON                      "Build with zlib."
+# ENABLE_ZLIB_UNCOMPRESS=OFF          "Use zlib to uncompress flate streams (not totally safe)."
+# USE_FLOAT=OFF                       "Use single precision arithmetic in the Splash backend"
+# BUILD_SHARED_LIBS=OFF               "Build poppler as a shared library"
+# RUN_GPERF_IF_PRESENT=OFF            "Run gperf if it is found"
+# EXTRA_WARN=OFF                      "Enable extra compile warnings"
+
+# The following packages are optional and only used if found:
+#   JPEG is required by pdf2htmlEX
+#   PNG  is required by pdf2htmlEX
+#   TIFF is not used by pdf2htmlEX
+#   NSS3 is not used by pdf2htmlEX?
+#   CAIRO is required by pdf2htmlEX
+#   GLIB is requrired by pdf2htmlEX
+#   GObjectIntrospection is not needed by pdf2htmlEX?
+#   Iconv is only used if ENABLE_CPP

--- a/buildScripts/buildPoppler
+++ b/buildScripts/buildPoppler
@@ -20,13 +20,13 @@ cmake                                       \
   -DBUILD_CPP_TESTS=OFF                     \
   -DENABLE_SPLASH=ON                        \
   -DENABLE_UTILS=OFF                        \
-  -DENABLE_CPP=ON                           \
+  -DENABLE_CPP=OFF                          \
   -DENABLE_GLIB=ON                          \
-  -DENABLE_GOBJECT_INTROSPECTION=ON         \
+  -DENABLE_GOBJECT_INTROSPECTION=OFF        \
   -DENABLE_GTK_DOC=OFF                      \
   -DENABLE_QT5=OFF                          \
   -DENABLE_LIBOPENJPEG="none"               \
-  -DENABLE_CMS="lcms2"                      \
+  -DENABLE_CMS="none"                       \
   -DENABLE_DCTDECODER="libjpeg"             \
   -DENABLE_LIBCURL=OFF                      \
   -DENABLE_ZLIB=ON                          \

--- a/buildScripts/getBuildToolsApt
+++ b/buildScripts/getBuildToolsApt
@@ -13,19 +13,19 @@ echo "-------------------------------------------------------------------"
 echo ""
 
 sudo apt-get update
-sudo apt-get $UNATTENDED install	\
-  aptitude				\
-  git					\
-  pkg-config				\
-  ruby					\
-  autoconf				\
-  libtool				\
-  cmake					\
-  make					\
-  gcc					\
-  g++					\
-  gettext				\
-  openjdk-8-jre-headless		\
-  jq					\
+sudo apt-get $UNATTENDED install \
+  aptitude                       \
+  git                            \
+  pkg-config                     \
+  ruby                           \
+  autoconf                       \
+  libtool                        \
+  cmake                          \
+  make                           \
+  gcc                            \
+  g++                            \
+  gettext                        \
+  openjdk-8-jre-headless         \
+  jq                             \
   tree
 

--- a/buildScripts/getDevLibrariesApt
+++ b/buildScripts/getDevLibrariesApt
@@ -14,13 +14,16 @@ echo "-------------------------------------------------------------------"
 echo ""
 
 sudo apt-get update
-sudo apt-get $UNATTENDED install	\
-  libcairo-dev				\
-  libspiro-dev				\
-  libpng-dev				\
-  libjpeg-dev				\
-  libpango1.0-dev			\
-  liblcms2-dev				\
-  libxml2-dev				\
-  libuninameslist-dev			\
-  python3-dev
+sudo apt-get $UNATTENDED install \
+  libcairo-dev                   \
+  libpng-dev                     \
+  libjpeg-dev                    \
+
+
+#  libspiro-dev				\
+#  libpango1.0-dev			\
+#  liblcms2-dev				\
+#  libxml2-dev				\
+#  libuninameslist-dev			\
+#  python3-dev
+

--- a/buildScripts/getDevLibrariesApt
+++ b/buildScripts/getDevLibrariesApt
@@ -18,12 +18,11 @@ sudo apt-get $UNATTENDED install \
   libcairo-dev                   \
   libpng-dev                     \
   libjpeg-dev                    \
-
+  libxml2-dev                    \
 
 #  libspiro-dev				\
 #  libpango1.0-dev			\
 #  liblcms2-dev				\
-#  libxml2-dev				\
 #  libuninameslist-dev			\
 #  python3-dev
 

--- a/pdf2htmlEX/CMakeLists.txt
+++ b/pdf2htmlEX/CMakeLists.txt
@@ -82,19 +82,20 @@ set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS}
   -lfreetype
   -lfontconfig
   -ljpeg
-  -lz
-  -llcms2
   -lpng
   -lz
-  -llcms2
   -pthread
-  -lspiro
-  -luninameslist
   -lm
   -lxml2
   -lglib-2.0
   -lgio-2.0
 )
+
+#  -llcms2
+#  -lz
+#  -llcms2
+#  -lspiro
+#  -luninameslist
 
 # debug build flags (overwrite default cmake debug flags)
 set(CMAKE_C_FLAGS_DEBUG "-ggdb -pg")


### PR DESCRIPTION
Turned off unused options for both Poppler (0.89.0) and FontForge (20200314)
Removed unused (apt) pacakges
Proved that we can build on xenial (16.04), bionic(18.04), focal(20.04) (and probably eoan (19.10))